### PR TITLE
Fix singularity alignment pair search

### DIFF
--- a/libs/quadretopology/quadretopology/includes/qr_ilp.cpp
+++ b/libs/quadretopology/quadretopology/includes/qr_ilp.cpp
@@ -319,6 +319,13 @@ inline void solveILP(
                                     }
                                     const ChartSide& adjOppositeSide = currentChart.chartSides[adjOppositeSideId];
 
+                                    if (adjOppositeSide.subsides.size() != 1) {
+                                        currentChartId = -1;
+                                        currentChartSideId = -1;
+                                        currentChartNSides = 0;
+                                        break;
+                                    }
+
                                     const std::array<int, 2>& incidentCharts = chartData.subsides[adjOppositeSide.subsides[0]].incidentCharts;
                                     const std::array<int, 2>& incidentChartSides = chartData.subsides[adjOppositeSide.subsides[0]].incidentChartSideId;
 
@@ -338,7 +345,12 @@ inline void solveILP(
 
                             } while (currentChartId != static_cast<int>(cId) && currentChartId > -1 && currentChartNSides == 4);
 
-                            if (currentChartId != static_cast<int>(cId) && currentChartId > -1 && (currentChartNSides == 3 || currentChartNSides == 5 || currentChartNSides == 6)) {
+
+                            if (currentChartId != static_cast<int>(cId)
+                                    && currentChartId > -1
+                                    && (currentChartNSides == 3 || currentChartNSides == 5 || currentChartNSides == 6)
+                                    && chartData.charts[currentChartId].chartSides[currentChartSideId].subsides.size() == 1)
+                            {
                                 bool currentComputable = true;
                                 for (size_t i = 0; i < chartData.charts[currentChartId].chartSubsides.size(); i++) {
                                     const size_t subsideId = chartData.charts[currentChartId].chartSubsides[i];
@@ -638,7 +650,14 @@ inline void solveILP(
                                         if (currentChartId != static_cast<int>(cId)) {
                                             adjOppositeSideId = (currentChartSideId + 2) % chartData.charts[currentChartId].chartSides.size();
                                         }
+
                                         const ChartSide& adjOppositeSide = currentChart.chartSides[adjOppositeSideId];
+                                        if (adjOppositeSide.subsides.size() != 1) {
+                                            currentChartId = -1;
+                                            currentChartSideId = -1;
+                                            currentChartNSides = 0;
+                                            break;
+                                        }
 
                                         const std::array<int, 2>& incidentCharts = chartData.subsides[adjOppositeSide.subsides[0]].incidentCharts;
                                         const std::array<int, 2>& incidentChartSides = chartData.subsides[adjOppositeSide.subsides[0]].incidentChartSideId;
@@ -659,7 +678,11 @@ inline void solveILP(
 
                                 } while (currentChartId != static_cast<int>(cId) && currentChartId > -1 && currentChartNSides == 4);
 
-                                if (currentChartId != static_cast<int>(cId) && currentChartId > -1 && (currentChartNSides == 3 || currentChartNSides == 5 || currentChartNSides == 6)) {
+                                if (currentChartId != static_cast<int>(cId)
+                                        && currentChartId > -1
+                                        && (currentChartNSides == 3 || currentChartNSides == 5 || currentChartNSides == 6)
+                                        && chartData.charts[currentChartId].chartSides[currentChartSideId].subsides.size() == 1)
+                                {
                                     bool currentComputable = true;
                                     for (size_t i = 0; i < chartData.charts[currentChartId].chartSubsides.size(); i++) {
                                         const size_t subsideId = chartData.charts[currentChartId].chartSubsides[i];


### PR DESCRIPTION
I noticed a difference between code and paper:
It will add alignment constraints for pairs of charts where some sides on the path between them have more than one subside. I assume this is unintentional (as the induced alignment constraints will in general not correspond to proper alignment)?.

This patch adjusts `qr_ilp.cpp` to only use pairs where all sides on the path consist of only a single subside.

I also noticed the code explicitly disables constraints for self-pairings (comparing `currentChartId` vs `cId`) - is this intentional?

Fair warning: I did not check how this affects the quality of results.
Hope you'll find this PR useful!

(By the way, thank you very much for sharing your code and thus enabling people to experiment with it and build on top of it!)